### PR TITLE
Update image URL and improve CI/CD clarity

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -48,7 +48,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: nokodo/twitchdropsminer # Replace if your repo name is different
+          images: nokodo/twitchdropsminer
           # Define tagging strategy:
           # - 'dev' tag for pushes to the 'dev' branch
           # - 'latest' tag for pushes to the 'stable' branch

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ FROM jlesage/baseimage-gui:alpine-3.18-v4.7
 ENV LANG=en_US.UTF-8 \
     DARK_MODE=1 \
     KEEP_APP_RUNNING=1 \
-    APP_ICON_URL=https://raw.githubusercontent.com/Davixk/TwitchDropsMiner-Alpine/stable/appimage/pickaxe.png
+    APP_ICON_URL=https://raw.githubusercontent.com/Davixk/TwitchDropsMiner/stable/appimage/pickaxe.png
 
 # Install runtime dependencies only
 RUN add-pkg \


### PR DESCRIPTION
Correct the APP_ICON_URL to ensure assets load from the intended repository and remove an unnecessary comment in the CI/CD workflow for better clarity.